### PR TITLE
compatiblitity layer php fixed #22 installation instruction fixed #21

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,30 @@
+# OSTicket-plugin-TinyMCE INSTALLATION
+
+Download the plugin content and place the contents into your include/plugins directory, then enable it and then configure it.
+
+## Download files
+
+For the osticket, go to plugin directory and clone/download-zip there with own directory name, could be as:
+
+1. by cloning: `cd include/plugins && git clone https://github.com/indefero/OSTicket-plugin-TinyMCE.git tinymce`
+2. by master lasted: `wget https://github.com/Micke1101/OSTicket-plugin-TinyMCE/archive/master.tar.gz`
+
+## Enabling pluguin
+
+Once files are there, go to admin panel and in plugins select `Add new plugin`, select `TinyMCE` and click install.
+
+## Configuring
+
+First need to link js files, on the server this can be done by two ways:
+1. in the plugin directory of tinymce, by linking soft as: `ln -s js/tinymce ../../../js/tinymce`
+2. in the plugin directory of tinymce, by copy content to js dir: `cp js/tinymce ../../../js/tinymce`
+
+Once installing go to admin panel and in plugins select it and enable it, once plugin are enabled then configure it by clicking.
+
+## To Remove:
+
+Navigate to admin plugins view, click the checkbox and push the "Delete" button.
+
+The plugin will still be available, you have deleted the config only at this point, 
+to remove after deleting, remove the related directory inside plugins directory..
+

--- a/class.TinyMCEPlugin.php
+++ b/class.TinyMCEPlugin.php
@@ -11,6 +11,21 @@ class TinyMCEPlugin extends Plugin {
     public $config_class = 'TinyMCEPluginConfig';
     
     /**
+     * Singleton reference to itself, used for static functions to find the one object.
+     * @var type 
+     */
+    static $instance = null;
+
+    /**
+     * Explicitly define a constructor, to wrap a $this reference as $instance
+     * @param type $id
+     */
+    public function __construct($id) {
+        parent::__construct($id);
+        self::$instance = $this;
+    }
+
+    /**
      * Run on every instantiation of osTicket..
      * needs to be concise
      *
@@ -23,18 +38,18 @@ class TinyMCEPlugin extends Plugin {
         register_shutdown_function(function () {
             $html = ob_get_clean();
             $javascript = file_get_contents(__DIR__ . '/tinymce-config.js');
-            $javascript = $this->handleConfig($javascript);
+            $javascript = TinyMCEPlugin::$instance->handleConfig($javascript);
             $html = preg_replace('/<script[^<]*redactor[^<]*><\/script>/', '', $html);
-            print str_replace("</head>", $this->includeTinyMCE() . "<script>" 
+            print str_replace("</head>", TinyMCEPlugin::$instance->includeTinyMCE() . "<script>" 
             . $javascript 
             . "</script><script type=\"text/javascript\" src=\"" 
-                    . ROOT_PATH . "include/" . $this->getInstallPath() 
+                    . ROOT_PATH . "include/" . TinyMCEPlugin::$instance->getInstallPath() 
 					. "/tinymce-osticket.min.js\"></script></head>", $html);
         });
     }
     
     function includeTinyMCE(){
-        $config = $this->getConfig();
+        $config = TinyMCEPlugin::$instance->getConfig();
         switch($config->get('jsfile')){
             case 'cloud':
                 return "<script type=\"text/javascript\" src=\"https://cloud.tinymce.com/stable/tinymce.min.js?apiKey=" . $config->get('apikey') . "\"></script>";
@@ -47,21 +62,21 @@ class TinyMCEPlugin extends Plugin {
     
     function handleConfig($html){
         global $thisstaff;
-        $config = $this->getConfig();
+        $config = TinyMCEPlugin::$instance->getConfig();
         $lang = Internationalization::getCurrentLanguage();
         $html = str_replace("{TINYMCE_HEIGHT}", $config->get('height'), $html);
         $html = str_replace("{TINYMCE_THEME}", $config->get('theme'), $html);
         $html = str_replace("{TINYMCE_SKIN}", $config->get('skin'), $html);
         $html = str_replace("{TINYMCE_PLUGINS}", ((is_array($config->get('plugins'))) ? implode(' ', array_keys($config->get('plugins'))) : '') . (($config->get('doautosave'))?" autosave":""), $html);
-        $html = str_replace("{TINYMCE_MENUBAR}", (boolval($config->get('menubar')) ? 'true':'false'), $html);
-        $html = str_replace("{TINYMCE_POWERED_BY}", (boolval($config->get('poweredby')) ? 'true':'false'), $html);
-		$html = str_replace("{TINYMCE_BROWSER_SPELLCHECK}", (boolval($config->get('browserspellcheck')) ? 'true':'false'), $html);
+        $html = str_replace("{TINYMCE_MENUBAR}", ( !! ($config->get('menubar')) ? 'true':'false'), $html);
+        $html = str_replace("{TINYMCE_POWERED_BY}", ( !! ($config->get('poweredby')) ? 'true':'false'), $html);
+		$html = str_replace("{TINYMCE_BROWSER_SPELLCHECK}", ( !! ($config->get('browserspellcheck')) ? 'true':'false'), $html);
         $html = str_replace("{TINYMCE_STAFF_PLUGINS}", ($thisstaff ? ' autolock signature contexttypeahead cannedresponses':''), $html);
         $html = str_replace("{TINYMCE_LANGUAGE}", ((file_exists($_SERVER[DOCUMENT_ROOT] . ROOT_PATH . "js/tinymce/langs/" . $lang . ".js")) ? "language: '" . $lang . "'," : ""), $html);
         if($config->get('doautosave')){
             $html = str_replace("{TINYMCE_AUTOSAVEOPTIONS}", "autosave_interval: \"" 
                 . $config->get('autosaveinterval') . "s\",autosave_restore_when_empty: " 
-                . (boolval($config->get('tryrestoreempty')) ? 'true':'false') 
+                . (!! ($config->get('tryrestoreempty')) ? 'true':'false') 
                 . ",autosave_retention: \"" . $config->get('autosaveretention') . "m\",", $html);
         } else {
             $html = str_replace("{TINYMCE_AUTOSAVEOPTIONS}", "", $html);

--- a/config.php
+++ b/config.php
@@ -41,12 +41,12 @@ class TinyMCEPluginConfig extends PluginConfig
             foreach(preg_grep('/^([^.])/', $skinsfound) as $skin)
                 $skins[$skin] = $skin;
         return array(
-            'mainoptions' => new SectionBreakField([
+            'mainoptions' => new SectionBreakField(array(
                 'label' => $__('Main options'),
                 'hint' => $__('Mainly visual settings.'),
                 'default' => TRUE
-            ]),
-            'plugins' => new ChoiceField([
+            )),
+            'plugins' => new ChoiceField(array(
                 'label' => $__('Plugins'),
                 'required' => false,
                 'hint' => $__('What plugins do you want to load.'),
@@ -121,55 +121,55 @@ class TinyMCEPluginConfig extends PluginConfig
                         'tinymcespellchecker' => __('Spell checker'),
                     ),
                 )
-            ]),
-            'toolbar' => new TextareaField([
+            )),
+            'toolbar' => new TextareaField(array(
                 'label' => $__('Toolbar'),
                 'required' => false,
                 'configuration'=>array('cols'=>50,'length'=>1024,'rows'=>4,'html'=>false),
                 'hint' => sprintf($__('How do you want your toolbar to look like, %s'), '<a href="https://www.tinymce.com/docs/configure/editor-appearance/#toolbar">Toolbar</a>'),
                 'default' => 'insert | undo redo |  styleselect | bold italic backcolor  | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help'
-            ]),
-            'theme' => new ChoiceField([
+            )),
+            'theme' => new ChoiceField(array(
                 'label' => $__('Theme'),
                 'required' => true,
                 'hint' => $__('What theme do you want to use.'),
                 'default' => 'modern',
                 'choices' => $themes
-            ]),
-            'skin' => new ChoiceField([
+            )),
+            'skin' => new ChoiceField(array(
                 'label' => $__('Skin'),
                 'required' => true,
                 'hint' => sprintf($__('What skin do you want to use. %s'), '<a href="http://skin.tinymce.com/">Skin creator</a>'),
                 'default' => 'lightgray',
                 'choices' => $skins
-            ]),
-            'browserspellcheck' => new BooleanField([
+            )),
+            'browserspellcheck' => new BooleanField(array(
                 'label' => $__('Browser spellchecker'),
                 'required' => false,
                 'hint' => $__('Enable the browsers native spellchecker.'),
                 'default' => true
-            ]),
-            'menubar' => new BooleanField([
+            )),
+            'menubar' => new BooleanField(array(
                 'label' => $__('Show menubar'),
                 'required' => false,
                 'hint' => $__('Display the menubar or not.'),
                 'default' => true
-            ]),
-            'poweredby' => new BooleanField([
+            )),
+            'poweredby' => new BooleanField(array(
                 'label' => $__('Show powered by message'),
                 'required' => false,
                 'hint' => $__('Display the powered by message or not.'),
                 'default' => true
-            ]),
-            'height' => new TextboxField([
+            )),
+            'height' => new TextboxField(array(
                 'label' => $__('Height'),
                 'required' => true,
                 'size'=>16,
                 'validator' => 'number',
                 'hint' => $__('The default height of TinyMCE'),
                 'default' => 250
-            ]),
-            'jsfile' => new ChoiceField([
+            )),
+            'jsfile' => new ChoiceField(array(
                 'label' => $__('TinyMCE source'),
                 'required' => true,
                 'hint' => $__('Where do you want to load TinyMCE from.'),
@@ -178,47 +178,47 @@ class TinyMCEPluginConfig extends PluginConfig
                     'js' => sprintf(__('Javascript folder (%s)'), 'js/tinymce'),
                     'cloud' => __('Cloud hosted'),
                 )
-            ]),
-            'apikey' => new TextboxField([
+            )),
+            'apikey' => new TextboxField(array(
                 'label' => $__('TinyMCE API Key'),
                 'required' => false,
                 'size'=>16,
                 'hint' => sprintf($__('If you\'re using cloud hosted TinyMCE you may require an API key.<br/>%sSign up for a API key%s'), '<a href="https://store.ephox.com/signup/">', '</a>'),
                 'default' => ''
-            ]),
-            'autosaveoptions' => new SectionBreakField([
+            )),
+            'autosaveoptions' => new SectionBreakField(array(
                 'label' => $__('Autosave options'),
                 'hint' => $__('The options regarding autosaving/drafts.'),
                 'default' => TRUE
-            ]),
-            'doautosave' => new BooleanField([
+            )),
+            'doautosave' => new BooleanField(array(
                 'label' => $__('Enable autosaving'),
                 'required' => false,
                 'hint' => $__('TinyMCE will create drafts automaticly.'),
                 'default' => true
-            ]),
-            'autosaveinterval' => new TextboxField([
+            )),
+            'autosaveinterval' => new TextboxField(array(
                 'label' => $__('Autosave frequency'),
                 'required' => false,
                 'size'=>16,
                 'validator' => 'number',
                 'hint' => $__('How long between each save in seconds.'),
                 'default' => '30'
-            ]),
-            'tryrestoreempty' => new BooleanField([
+            )),
+            'tryrestoreempty' => new BooleanField(array(
                 'label' => $__('Restore when empty'),
                 'required' => false,
                 'hint' => $__('If the user has a draft available restore it automaticly.'),
                 'default' => true
-            ]),
-            'autosaveretention' => new TextboxField([
+            )),
+            'autosaveretention' => new TextboxField(array(
                 'label' => $__('Draft lifespan'),
                 'required' => false,
                 'size'=>16,
                 'validator' => 'number',
                 'hint' => $__('How long should a draft be stored for in minutes.'),
                 'default' => '30'
-            ]),
+            )),
         );
     }
 }


### PR DESCRIPTION
compatibility layer for osticket 1.9 and php 5.3 with 5.4/7.0

+ dont use declarative arrays from 5.4, use explicy array() sintax
+ fixed "Fatal error: Call to undefined function boolval()" by use implict !! conversion
+ dont use $this in anonymouos finction calls, use self and assume static SSO behaviour
+ asume php 5.3 adn 5.4/7.X compatible due functions dont have self paring arguments

this fixed #22 

aditional added installation instructions fixed #21 